### PR TITLE
Update minimum cmake to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # 4. create usable libtool .la file
 # 5. runtest not created
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.16)
 
 PROJECT(libzip C)
 


### PR DESCRIPTION
Make cmake version consistent and bump it to 3.16 (comes with ubuntu 20.04).
Compatibility with cmake < 3.5 was removed in cmake 4